### PR TITLE
**Changed:** VSIX Manifest file to allow Extension to run in Visual Studio 2019.

### DIFF
--- a/ProjectHero2/source.extension.vsixmanifest
+++ b/ProjectHero2/source.extension.vsixmanifest
@@ -12,15 +12,15 @@
         <Tags>Build, C++, C#, Visualization, MS Build</Tags>
     </Metadata>
     <Installation>
-        <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[15.0,16.0]" />
-        <InstallationTarget Version="[15.0,16.0]" Id="Microsoft.VisualStudio.Enterprise" />
-        <InstallationTarget Version="[15.0,16.0]" Id="Microsoft.VisualStudio.Pro" />
+        <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[15.0,17.0]" />
+        <InstallationTarget Version="[15.0,17.0]" Id="Microsoft.VisualStudio.Enterprise" />
+        <InstallationTarget Version="[15.0,17.0]" Id="Microsoft.VisualStudio.Pro" />
     </Installation>
     <Dependencies>
         <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
     </Dependencies>
     <Prerequisites>
-        <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,16.0]" DisplayName="Visual Studio core editor" />
+        <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,17.0]" DisplayName="Visual Studio core editor" />
     </Prerequisites>
     <Assets>
         <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />


### PR DESCRIPTION
I've had a look into this one and I believe these changes should allow the Extension to be installed for Visual Studio 2019.

Comment on original Issue: #8: [VSIX will not install into Visual Studio Community 2019 (Version 16.4.5)](https://github.com/RedOrc/ProjectHero2/issues/8)

This involved some minor updates to the Manifest file to allow later Versions of Visual Studio and also updated the Version Range for the 'Microsoft.VisualStudio.Component.CoreEditor' prerequisite.

Hope this helps!